### PR TITLE
Improve Monit polling behavior during monitored process restart

### DIFF
--- a/chronos.root/usr/share/chronos/chronos.monit
+++ b/chronos.root/usr/share/chronos/chronos.monit
@@ -39,14 +39,14 @@ check process chronos_process with pidfile /var/run/chronos/chronos.pid
   group chronos
 
   # The start, stop and restart commands are linked to alarms
-  start program = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 3000.4; /etc/init.d/chronos start'"
+  start program = "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/chronos-stability reset; /usr/share/clearwater/bin/issue-alarm monit 3000.4; /etc/init.d/chronos start'"
   stop program  = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 3000.4; /etc/init.d/chronos stop'"
-  restart program = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 3000.4; /etc/init.d/chronos restart'"
+  restart program = "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/chronos-stability reset; /usr/share/clearwater/bin/issue-alarm monit 3000.4; /etc/init.d/chronos restart'"
 
   # Check the service's resource usage, and abort the process if it's too high. This will
   # generate a core file and trigger diagnostics collection. Monit will raise an alarm when
   # it restarts the process
-  if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 3000.4; /etc/init.d/chronos abort'"
+  if memory > 80% then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/chronos-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 3000.4; /etc/init.d/chronos abort'"
 
 # Clear any alarms if the process has been running long enough.
 check program chronos_uptime with path /usr/share/clearwater/infrastructure/monit_uptime/check-chronos-uptime
@@ -63,4 +63,4 @@ check program poll_chronos with path "/usr/share/clearwater/bin/poll_chronos.sh"
 
   # Aborting generates a core file and triggers diagnostic collection. Monit will raise
   # an alarm when it restarts the process
-  if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/chronos/write_monit_restart_diags; /usr/share/clearwater/bin/issue-alarm monit 3000.4; /etc/init.d/chronos abort'"
+  if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/chronos-stability aborted; /usr/share/chronos/write_monit_restart_diags; /usr/share/clearwater/bin/issue-alarm monit 3000.4; /etc/init.d/chronos abort'"

--- a/chronos.root/usr/share/clearwater/bin/poll_chronos.sh
+++ b/chronos.root/usr/share/clearwater/bin/poll_chronos.sh
@@ -36,4 +36,16 @@
 
 . /etc/clearwater/config
 /usr/share/clearwater/bin/poll-http localhost:7253
-exit $?
+rc=$?
+
+# If the chronos process is not stable, we ignore a non-zero return code and
+# return zero.
+if [ $rc != 0 ]; then
+  /usr/share/clearwater/infrastructure/monit_stability/chronos-stability check
+  if [ $? != 0 ]; then
+    echo "return code $rc ignored" >&2
+    rc=0
+  fi
+fi
+
+exit $rc

--- a/chronos.root/usr/share/clearwater/infrastructure/monit_stability/chronos-stability
+++ b/chronos.root/usr/share/clearwater/infrastructure/monit_stability/chronos-stability
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# @file chronos-stability
+#
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+# Used for monitoring the stability of the chronos process.
+
+PROCESS_NAME="chronos"
+GRACE_PERIOD=20
+
+method=$1
+
+/usr/share/clearwater/bin/process-stability $method $PROCESS_NAME $GRACE_PERIOD
+exit $?


### PR DESCRIPTION
This is a process-specific fix for [#59](https://github.com/ClearwaterCore/clearwater-infrastructure/pull/59).